### PR TITLE
Update reporter to get flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target/
 *.ipr
 *.iws
+.idea/
+classes/
+src/main/java/META-INF/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ target/
 *.iws
 .idea/
 classes/
-src/main/java/META-INF/
+src/main/resources/META-INF/

--- a/.idea/libraries/Maven__com_github_pcj_google_options_1_0_0.xml
+++ b/.idea/libraries/Maven__com_github_pcj_google_options_1_0_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.github.pcj:google-options:1.0.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/pcj/google-options/1.0.0/google-options-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/pcj/google-options/1.0.0/google-options-1.0.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/pcj/google-options/1.0.0/google-options-1.0.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_code_findbugs_jsr305_3_0_1.xml
+++ b/.idea/libraries/Maven__com_google_code_findbugs_jsr305_3_0_1.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.code.findbugs:jsr305:3.0.1">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/code/findbugs/jsr305/3.0.1/jsr305-3.0.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__com_google_guava_guava_19_0.xml
+++ b/.idea/libraries/Maven__com_google_guava_guava_19_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.google.guava:guava:19.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/19.0/guava-19.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/19.0/guava-19.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/guava/guava/19.0/guava-19.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/java-sdk-tester.iml
+++ b/java-sdk-tester.iml
@@ -1,97 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" relativePaths="false" type="JAVA_MODULE" version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/junit/junit/3.8.1/junit-3.8.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.4.1/jackson-core-2.4.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/2.4.1/jackson-jaxrs-json-provider-2.4.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/jaxrs/jackson-jaxrs-base/2.4.1/jackson-jaxrs-base-2.4.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.4.1/jackson-databind-2.4.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.4.0/jackson-annotations-2.4.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.4.1/jackson-module-jaxb-annotations-2.4.1.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-core/2.2/log4j-core-2.2.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MAVEN_REPOSITORY$/org/apache/logging/log4j/log4j-api/2.2/log4j-api-2.2.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:3.8.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.2" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.2" level="project" />
@@ -101,5 +20,8 @@
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.4.1" level="project" />
+    <orderEntry type="library" name="Maven: com.github.pcj:google-options:1.0.0" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
        <artifactId>jackson-jaxrs-json-provider</artifactId>
        <version>${jackson.version}</version>
      </dependency>
+    <dependency>
+      <groupId>com.github.pcj</groupId>
+      <artifactId>google-options</artifactId>
+      <version>1.0.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/alooma/javatester/App.java
+++ b/src/main/java/com/alooma/javatester/App.java
@@ -1,49 +1,49 @@
 package com.alooma.javatester;
 
+import com.google.devtools.common.options.OptionsParser;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.SocketAppender;
-import org.apache.logging.log4j.core.layout.JsonLayout;
-import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
-import org.apache.logging.log4j.core.net.ssl.StoreConfigurationException;
-import org.apache.logging.log4j.core.net.ssl.TrustStoreConfiguration;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.util.Collections;
+
 import static org.apache.logging.log4j.LogManager.getLogger;
 
-/**
- * Hello world!
- *
- */
 public class App {
 	private static final Logger reporter = getLogger("alooma-reporter");
 
-    public static void main( String[] args ) {
-		if (args.length != 2) {
-			System.out.println("Usage: java -jar javasdk-tester.jar <alooma hostname> <num of messages>");
-			return;
-		}
+	public static void main( String[] args ) {
+        OptionsParser parser = OptionsParser.newOptionsParser(TesterParser.class);
+        parser.parseAndExitUponError(args);
+        TesterParser options = parser.getOptions(TesterParser.class);
+        if (options.numOfEvents == 0 || options.host.isEmpty() || options.token.isEmpty()){
+            printUsage(parser);
+            return;
+        }
 
-		int msgNum = Integer.parseInt(args[1]);
-
-		Layout<String> jsonLayout = JsonLayout.createLayout(false, false, false, true, true, null);
+		Layout<String> patternLayout = PatternLayout.createDefaultLayout();
+		ConsoleAppender.createDefaultAppenderForLayout(patternLayout);
 		SocketAppender socketAppender;
 		socketAppender = SocketAppender.createAppender(
-				args[0], // alooma hostname
-				"5001",
-				"SSL", // protocol = "SSL"
-				null,
-				0,
-				null,
-				null,
+				options.host, // alooma hostname
+				options.port,
+				options.protocol, // protocol = "SSL"
+				null, 0, null, null,
 				"Alooma", // Logger name
 				"true", // immediateFlush = true
-				null,
-				jsonLayout,
-				null, null, null);
+				null, patternLayout, null, null, null);
 		socketAppender.start();
 		((org.apache.logging.log4j.core.Logger)reporter).addAppender(socketAppender);
-		for (int i = 0; i < msgNum; i++) {
-			reporter.info("{\"type\":\"java-sdk-tester\",\"message\":\"your message\",\"num\":{}}", i);
+		for (int i = 0; i < options.numOfEvents; i++) {
+			reporter.info("{\"token\":\"" + options.token + "\",\"message\":{\"stringField\":\"Java reporter - tester\",\"numField\":" + i +"}}");
 		}
-		System.out.println( "Hello World!" );
+	}
+
+    private static void printUsage(OptionsParser parser) {
+        System.out.println("Usage: java -jar javasdk-tester-new.jar OPTIONS");
+        System.out.println(parser.describeOptions(Collections.<String, String>emptyMap(),
+                OptionsParser.HelpVerbosity.LONG));
     }
 }

--- a/src/main/java/com/alooma/javatester/TesterParser.java
+++ b/src/main/java/com/alooma/javatester/TesterParser.java
@@ -1,0 +1,63 @@
+package com.alooma.javatester;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionsBase;
+import java.lang.String;
+
+/**
+ * Created by yonatankiron on 19/03/2017.
+ */
+public class TesterParser extends OptionsBase {
+
+    @Option(
+            name = "help",
+            abbrev = 'h',
+            help = "Prints usage info.",
+            defaultValue = "true"
+    )
+    public boolean help;
+
+    @Option(
+            name = "hostname",
+            abbrev = 'o',
+            help = "The server host.",
+            category = "startup",
+            defaultValue = ""
+    )
+    public String host;
+
+    @Option(
+            name = "port",
+            abbrev = 'p',
+            help = "The server port.",
+            category = "startup",
+            defaultValue = "5001"
+    )
+    public String port;
+
+    @Option(
+            name = "num",
+            abbrev = 'n',
+            help = "Number of messages.",
+            category = "startup",
+            defaultValue = "0"
+    )
+    public int numOfEvents;
+
+    @Option(
+            name = "protocol",
+            help = "Which protocol to use.",
+            category = "startup",
+            defaultValue = "SSL"
+    )
+    public String protocol;
+
+    @Option(
+            name = "token",
+            abbrev = 't',
+            help = "Token.",
+            category = "startup",
+            defaultValue = ""
+    )
+    public String token;
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -5,14 +5,8 @@
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{ISO8601} [%t] %-5level %logger{36} - %msg%n" />
     </Console>
-    <Socket name="Alooma" host="rami-dev-i.alooma.io" port="5001" protocol="SSL" immediateFlush="true">
-      <JSONLayout compact="true" eventEol="true" />
-    </Socket>
   </Appenders>
   <Loggers>
-      <Logger name="com.alooma" level="debug" additivity="false">
-      <AppenderRef ref="Alooma" />
-    </Logger>
     <Root level="info">
       <AppenderRef ref="Console" />
     </Root>


### PR DESCRIPTION
Since we removed Generic_input, and we want to test java_reporter with eventstash.
I added flags to the tester, which should be easier to use and faster then the python reporter.